### PR TITLE
fix(build): 修正具有网状依赖时无法正常构建的问题

### DIFF
--- a/include/build.h
+++ b/include/build.h
@@ -28,6 +28,7 @@ class Build
 {
     BuildInfo info;
     ConfigInfo config;
+    std::unordered_set<std::string> build_depends;
 
 public:
     Build(const BuildInfo &info, const ConfigInfo &config);

--- a/src/build.cpp
+++ b/src/build.cpp
@@ -51,7 +51,13 @@ void Build::generate_cmake_root(cmake::Generator &gen)
     const char *STATIC = "static";
     const char *SHARED = "shared";
     for (const auto &[name, cup] : this->config.dependencies)
-        this->generate_cmake_sub(cup.path, gen);
+    {
+        if (this->build_depends.find(name) == this->build_depends.end())
+        {
+            this->generate_cmake_sub(cup.path, gen);
+            this->build_depends.insert(name);
+        }
+    }
     auto src_files = fs::exists(this->info.project_dir / "src")
                          ? find_all_source(this->info.project_dir / "src")
                          : std::vector<fs::path>{};
@@ -188,7 +194,13 @@ void Build::generate_cmake_sub(const fs::path &path, cmake::Generator &gen)
     auto project_dir = path.is_relative() ? this->info.project_dir / path : path;
     Config config(project_dir);
     for (const auto &[name, cup] : config.config->dependencies)
-        this->generate_cmake_sub(cup.path, gen);
+    {
+        if (this->build_depends.find(name) == this->build_depends.end())
+        {
+            this->generate_cmake_sub(cup.path, gen);
+            this->build_depends.insert(name);
+        }
+    }
     auto src_files = fs::exists(project_dir / "src")
                          ? find_all_source(project_dir / "src")
                          : std::vector<fs::path>{};


### PR DESCRIPTION
原先行为：当具有网状依赖时，未检查构建目标是否重复，导致会生成多个同名构建目标而无法正常构建