### PR TITLE
fix(build): 对compile_commands.json操作前检查其是否存在

### DIFF
--- a/src/build.cpp
+++ b/src/build.cpp
@@ -621,6 +621,12 @@ int Build::build()
 
     if (this->config.build.export_.has_value())
     {
+        auto src_path = this->info.build_dir / cmake_build / "compile_commands.json";
+
+        if (!fs::exists(src_path)) {
+            return 0;
+        }
+        
         auto export_ = this->config.build.export_.value();
         if (export_.compile_commands.has_value())
         {
@@ -631,7 +637,7 @@ int Build::build()
                 if (!fs::exists(path))
                     fs::create_directories(path);
                 fs::copy_file(
-                    this->info.build_dir / cmake_build / "compile_commands.json",
+                    src_path,
                     path / "compile_commands.json",
                     fs::copy_options::overwrite_existing);
             }


### PR DESCRIPTION
### 问题描述
在cup.toml中配置`compile_commands = ""`时，`cup build`命令发生错误：

`[Error] copy_file: 系统找不到指定的文件。: "C:\Users\lymon\cds\cxx\cup_pjc\build\cmake\compile_commands.json", "C:\Users\lymon\cds\cxx\cup_pjc\compile_commands.json"`

其中，`C:\Users\lymon\cds\cxx\cup_pjc`为我的项目根目录。

![cup_error](https://github.com/user-attachments/assets/9a3f6926-e9db-4283-acea-cc7c4eefe5b8)


### 原因
CMake官方文档在`CMAKE_EXPORT_COMPILE_COMMANDS`选项页面中表示：

> Note : This option is implemented only by [Makefile Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#makefile-generators) and [Ninja Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#ninja-generators). It is ignored on other generators.

因此在使用其他的生成器时，compile_commands.json并不会生成，而接下来代码中的`fs::copy_file`就会因为源文件不存在而报错。

### 解决方案之一
我添加了一段代码，代码会在操作compile_commands.json之前检查其是否存在，防止在该文件不存在时错误地执行`fs::copy_file`。


